### PR TITLE
Include pyd files into packaged plugin

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Amend gitignore to include embedded libs with qgis-plugin-ci
         run: |
+          sed -i 's/^\*\.py\[cod\].*//' .gitignore
           sed -i "s|^${{ env.PROJECT_FOLDER }}/embedded_external_libs/.*| |" .gitignore
           git add ${{ env.PROJECT_FOLDER }}/embedded_external_libs/
 
@@ -183,6 +184,7 @@ jobs:
 
       - name: Amend gitignore to include embedded libs with qgis-plugin-ci
         run: |
+          sed -i 's/^\*\.py\[cod\].*//' .gitignore
           sed -i "s|^${{ env.PROJECT_FOLDER }}/embedded_external_libs/.*| |" .gitignore
           git add ${{ env.PROJECT_FOLDER }}/embedded_external_libs/
 


### PR DESCRIPTION
Auto remove compiled python files from gitignore

#54 

See: https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll